### PR TITLE
Add POSIX style help messages

### DIFF
--- a/scripts/addAccessGroup.sh
+++ b/scripts/addAccessGroup.sh
@@ -3,6 +3,21 @@
 ACCESS_GROUP="${ACCESS_GROUP:-AppMod}"
 USER_LIST="${USER_LIST:-email.txt}"
 
+print_help(){
+cat << EOF
+Usage: $0 [OPTIONS]...
+
+Add users from a file to an access group.
+
+Mandatory arguments to long options are mandatory for short options too.
+  -g=, --access-group=STRING       add users to STRING access group
+                                       defaults to App-Mod
+  -u=,  --user-list=FILE           FILE where users email addresses are stored;
+                                       defaults to email.txt
+  -h   --help                      display this help and exit
+
+EOF
+}
 
 for OPT in "$@"; do
     case "$OPT" in
@@ -12,8 +27,13 @@ for OPT in "$@"; do
         -u=*|--user-list=*)
             USER_LIST="${OPT#*=}"
             ;;
+        -h|--help)
+            print_help
+            exit 0
+            ;;
         *)
             echo "Unexpected flag $OPT"
+            print_help
             exit 2
             ;;
     esac

--- a/scripts/configureClusters.sh
+++ b/scripts/configureClusters.sh
@@ -1,18 +1,41 @@
 #!/bin/bash
 
-CLUSTER_RANGE="${CLUSTER_RANGE:-1-50}"
+print_help(){
+cat << EOF
+Usage: $0 [OPTIONS]...
+
+Configure Clusters.
+
+Mandatory arguments to long options are mandatory for short options too.
+  -r=,  --cluster-range=NUM1-NUM2    range from NUM1 to NUM2 for cluster numbers;
+                                         defaults to 1-50
+  -h   --help                        display this help and exit
+
+EOF
+}
 
 for OPT in "$@"; do
     case "$OPT" in
         -r=*|--cluster-range=*)
             CLUSTER_RANGE="${OPT#*=}"
             ;;
+        -h|--help)
+            print_help
+            exit 0
+            ;;
         *)
             echo "Unexpected flag $OPT"
+            print_help
             exit 2
             ;;
     esac
 done
+
+if [[ -z $CLUSTER_RANGE ]]; then
+    echo "Error: cluster range required."
+    print_help
+    exit 3
+fi
 
 CSTART=$(cut -d'-' -f1 <<< "$CLUSTER_RANGE");
 CEND=$(cut -d'-' -f2 <<< "$CLUSTER_RANGE");

--- a/scripts/createClusters.sh
+++ b/scripts/createClusters.sh
@@ -8,16 +8,46 @@ PUBLIC_VLAN="${PUBLIC_VLAN:-2573693}"
 WORKER_NODE_COUNT="${WORKER_NODE_COUNT:-2}"
 ZONE="${ZONE:-wdc07}"
 
+print_help(){
+cat << EOF
+Usage: $0 [OPTIONS]...
+
+Create clusters.
+
+Mandatory arguments to long options are mandatory for short options too.
+  -r=,  --cluster-range=NUM1-NUM2    range from NUM1 to NUM2 for cluster numbers
+  -hw=, --hardware=STRING            hardware configuration for k8s;
+                                         defaults to shared
+      --kube-version=NUM             k8s version to install;
+                                         defaults to 1.12.6
+  -t=,  --machine-type=STRING        STRING machine configuration;
+                                         defaults to u2c.2x4
+      --private-vlan=NUM             use private vlan identified by NUM;
+                                         defaults to 2573695
+      --public-vlan=NUM              use public vlan identified by NUM;
+                                         defaults to 2573693
+  -c=,  --worker-node-count=NUM      NUM workers in cluster;
+                                         defaults to 2
+  -z=,  --zone=STRING                host clusters in STRING availabilty zone;
+                                         defaults to wdc07
+  -h   --help                        display this help and exit
+
+EOF
+}
+
 for OPT in "$@"; do
     case "$OPT" in
         -r=*|--cluster-range=*)
             CLUSTER_RANGE="${OPT#*=}"
             ;;
-        -h=*|--hardware=*)
+        -hw=*|--hardware=*)
             HARDWARE="${OPT#*=}"
             ;;
-        -t=*|--kube-version=*)
+        --kube-version=*)
             KUBE_VERSION="${OPT#*=}"
+            ;;
+        -t=*|--machine-type=*)
+            MACHINE_TYPE="${OPT#*=}"
             ;;
         --private-vlan=*)
             PRIVATE_VLAN="${OPT#*=}"
@@ -31,17 +61,22 @@ for OPT in "$@"; do
         -z=*|--zone=*)
             ZONE="${OPT#*=}"
             ;;
+        -h|--help)
+            print_help
+            exit 0
+            ;;
         *)
             echo "Unexpected flag $OPT"
+            print_help
             exit 2
             ;;
     esac
 done
 
 if [[ -z $CLUSTER_RANGE ]]; then
-    echo "Error: cluster range required..."
-    echo "Set it with --cluster-range=1-50...or whatever your range is..."
-    exit 2
+    echo "Error: cluster range required."
+    print_help
+    exit 3
 fi
 
 CSTART=$(cut -d'-' -f1 <<< "$CLUSTER_RANGE")

--- a/scripts/deleteClusters.sh
+++ b/scripts/deleteClusters.sh
@@ -1,21 +1,39 @@
 #!/bin/bash
 
+ print_help(){
+cat << EOF
+Usage: $0 [OPTIONS]...
+
+Delete Clusters.
+
+Mandatory arguments to long options are mandatory for short options too.
+  -r=,  --cluster-range=NUM1-NUM2    range from NUM1 to NUM2 for cluster numbers;
+  -h   --help                        display this help and exit
+
+EOF
+}
+
 for OPT in "$@"; do
     case "$OPT" in
         -r=*|--cluster-range=*)
             CLUSTER_RANGE="${OPT#*=}"
             ;;
+        -h|--help)
+            print_help
+            exit 0
+            ;;
         *)
             echo "Unexpected flag $OPT"
+            print_help
             exit 2
             ;;
     esac
 done
 
 if [[ -z $CLUSTER_RANGE ]]; then
-    echo "Error: cluster range required..."
-    echo "Set it with --cluster-range=1-50...or whatever your range is..."
-    exit 2
+    echo "Error: cluster range required."
+    print_help
+    exit 3
 fi
 
 CSTART=$(cut -d '-' -f1 <<< "$CLUSTER_RANGE");

--- a/scripts/inviteUsers.sh
+++ b/scripts/inviteUsers.sh
@@ -2,6 +2,20 @@
 
 USER_LIST="${USER_LIST:-email.txt}"
 
+print_help(){
+cat << EOF
+Usage: $0 [OPTIONS]...
+
+Invite users to join account
+
+Mandatory arguments to long options are mandatory for short options too.
+  -u=,  --user-list=FILE      FILE where users email addresses are stored;
+                                  defaults to email.txt
+  -h   --help                 display this help and exit
+
+EOF
+}
+
 for OPT in "$@"; do
     case "$OPT" in
         -u=*|--user-list=*)


### PR DESCRIPTION
Previously, users had to read the scripts to understand how to run them.
This was a party foul.

Now, all scripts print a help message with -h, --help, or unexpected
flags.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>